### PR TITLE
#21 use golang:1.13-alpine as unittest-exp image

### DIFF
--- a/golang/unittest-exp/Dockerfile
+++ b/golang/unittest-exp/Dockerfile
@@ -1,3 +1,3 @@
-FROM pangpanglabs/golang:builder-beta
+FROM golang:1.13-alpine
 
 RUN go get github.com/smartystreets/goconvey


### PR DESCRIPTION
Because each pull request requires unit testing, use dind (docker in docker)
Because dind is used, every time you do a go test, you need to download golang images. To save time and performance, use this image when performing unit tests: golang: 1.13-alpine

因为每一个pull request都需要进行单元测试，所以用dind（docker in docker）
因为用了dind，所以每次做go test时，都需要下载golang的images，为了节省时间和性能，所以执行单元测试时，使用这个镜像：golang:1.13-alpine